### PR TITLE
cfn-flip instead of cfn_flip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 boto3>=1.10.41
-cfn_flip>=1.2.2
+cfn-flip>=1.2.2

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(name='cfnlp',
       zip_safe=True,
       install_requires=[
           'boto3>=1.10.41',
-          'cfn_flip>=1.2.2'
+          'cfn-flip>=1.2.2'
       ],
       entry_points={'console_scripts': [
           'cfnlp = cfnlp.main:main'


### PR DESCRIPTION
https://pypi.org/project/cfn-flip/
Seemed to not install https://github.com/awslabs/aws-cfn-template-flip until I switched this?
```bash
from cfn_flip import to_json
ModuleNotFoundError: No module named 'cfn_flip'
```