### PR TITLE
Removed dash from SID generation

### DIFF
--- a/cfnlp/rolegen.py
+++ b/cfnlp/rolegen.py
@@ -46,7 +46,7 @@ class PermissionsManager:
         
         if lifecycle != "Update" or self.include_update_actions:
             tracked_permission = {
-                'Sid': '{}-{}{}{}{}'.format(resname, lifecycle, self.tracked_lifecycle_count[resname][lifecycle], non_mandatory_str, registry_str),
+                'Sid': '{}{}{}{}{}'.format(resname, lifecycle, self.tracked_lifecycle_count[resname][lifecycle], non_mandatory_str, registry_str),
                 'Effect': 'Allow',
                 'Action': actions,
                 'Resource': resources


### PR DESCRIPTION
IAM policies have a restriction on characters in the SID field and don't allow dashes (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_sid.html). I've removed the dash from the SID generation during rolegen.