### PR TITLE
Add supported resource AWS::SSM::Parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,5 @@ The following resource types are supported with a per-type mapping:
 * AWS::S3::Bucket
 * AWS::SNS::Topic
 * AWS::SQS::Queue
+* AWS::SSM::Parameter
+

--- a/cfnlp/mappings/ssm.py
+++ b/cfnlp/mappings/ssm.py
@@ -1,0 +1,39 @@
+class AWSSSMParameterPermissions:
+    def get_permissions(self, resname, res):
+        name = self._get_property_or_default(res, "*", "Name")
+
+        self.permissions.add(
+            resname=resname,
+            lifecycle='Create',
+            actions=[
+                'ssm:PutParameter',
+                'ssm:AddTagsToResource',
+            ],
+            resources=[
+                'arn:aws:ssm:{}:{}:parameter/{}'.format(self.region, self.accountid, name.lstrip("/"))
+            ]
+        )
+
+        self.permissions.add(
+            resname=resname,
+            lifecycle='Update',
+            actions=[
+                'ssm:RemoveTagsFromResource',
+                'ssm:GetParameter*'
+            ],
+            resources=[
+                'arn:aws:ssm:{}:{}:parameter/{}'.format(self.region, self.accountid, name.lstrip("/"))
+            ]
+        )
+
+        self.permissions.add(
+            resname=resname,
+            lifecycle='Delete',
+            actions=[
+                'ssm:RemoveTagsFromResource',
+                'ssm:DeleteParameter*'
+            ],
+            resources=[
+                'arn:aws:ssm:{}:{}:parameter/{}'.format(self.region, self.accountid, name.lstrip("/"))
+            ]
+        )

--- a/cfnlp/rolegen.py
+++ b/cfnlp/rolegen.py
@@ -11,6 +11,7 @@ from .mappings.s3 import *
 from .mappings.sns import *
 from .mappings.sqs import *
 from .mappings.route53 import *
+from .mappings.ssm import *
 
 
 class InvalidArguments(Exception):

--- a/tests/AWS-SSM-Parameter/create.yaml
+++ b/tests/AWS-SSM-Parameter/create.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: svcrolegen-AWS-SSM-Parameter
+Resources:
+  Parameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Name: /cfnlp/test
+      Value: "test"

--- a/tests/AWS-SSM-Parameter/role.yaml
+++ b/tests/AWS-SSM-Parameter/role.yaml
@@ -1,0 +1,45 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: svcrolegen-AWS-SSM-Parameter-role
+Resources:
+  CloudFormationServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: AWS-SSM-Parameter-cfnservicerole
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - cloudformation.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: "/"
+      Policies:
+        - PolicyName: SSM-Parameter-create
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:PutParameter
+                  - ssm:AddTagsToResource
+                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*
+        - PolicyName: SSM-Parameter-update
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:RemoveTagsFromResource
+                  - ssm:GetParameter*
+                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*
+        - PolicyName: SSM-Parameter-delete
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:RemoveTagsFromResource
+                  - ssm:DeleteParameter*
+                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*

--- a/tests/AWS-SSM-Parameter/update.yaml
+++ b/tests/AWS-SSM-Parameter/update.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: svcrolegen-AWS-SSM-Parameter
+Resources:
+  Parameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Name: /cfnlp/test
+      Value: "test2"


### PR DESCRIPTION
Add test templates for AWS::SSM::Parameter cfn service role
Add AWS::SSM::Parameter to supported resources in README.md

This is my first foray into aws-leastprivilege, so style tips appreciated.
The short goal for me is to cover every resource mentioned in `cdk bootstrap --show-template`.
m.