### PR TITLE
Fix no module named cfn_flip error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 boto3>=1.10.41
-cfn-flip>=1.2.2
+cfn-flip>=1.3.0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(name='cfnlp',
       zip_safe=True,
       install_requires=[
           'boto3>=1.10.41',
-          'cfn-flip>=1.2.2'
+          'cfn-flip>=1.3.0'
       ],
       entry_points={'console_scripts': [
           'cfnlp = cfnlp.main:main'


### PR DESCRIPTION
Hi, after installing, I found I get the error `ModuleNotFoundError: No module named 'cfn_flip'` when trying to use `cfnlp`.  To reproduce:

```bash
docker run -t --rm python:3.11 bash '-c' 'pip install cfnlp && cfnlp --help'
```
I found updating the minimum requirement appears to fix the issue for me.